### PR TITLE
[FIX] Version file update on runtime server instead of build server

### DIFF
--- a/CometServer/CometServer.csproj
+++ b/CometServer/CometServer.csproj
@@ -68,7 +68,7 @@
     </None>
   </ItemGroup>
   <PropertyGroup>
-    <VersionFileCreatorDll>../VersionFileCreator/bin/$(Configuration)/$(TargetFramework)/VersionFileCreator.dll</VersionFileCreatorDll>
+    <VersionFileCreatorDll>../VersionFileCreator/bin/$(Configuration)/VersionFileCreator.dll</VersionFileCreatorDll>
     <IsVersionFileCreatorCompiled>False</IsVersionFileCreatorCompiled>
     <IsVersionFileCreatorCompiled Condition="Exists('$(VersionFileCreatorDll)')">True</IsVersionFileCreatorCompiled>
   </PropertyGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ RUN dotnet build CDP4DatabaseAuthentication -c Release
 RUN dotnet build CDP4WspDatabaseAuthentication -c Release
 RUN dotnet publish -r linux-x64 CometServer -c Release -o /app/CometServer/bin/Release/publish
 
-COPY CometServer/bin/Release/linux-x64/VERSION /app/CometServer/bin/Release/publish/VERSION
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0.7-alpine3.20
 WORKDIR /app
 RUN mkdir /app/logs
@@ -23,6 +21,7 @@ RUN mkdir /app/upload
 RUN mkdir /app/Authentication/
 RUN mkdir /app/Authentication/CDP4Database
 RUN mkdir /app/Authentication/CDP4WspDatabase
+RUN mkdir /app/VersionFileCreator
 
 COPY --from=build-env /app/CometServer/bin/Release/publish .
 RUN rm /app/appsettings.Development.json
@@ -35,6 +34,10 @@ COPY --from=build-env /app/CDP4DatabaseAuthentication/bin/Release/config.json /a
 # COPY CDP4WspDatabaseAuthentication plugin
 COPY --from=build-env /app/CDP4WspDatabaseAuthentication/bin/Release/CDP4WspDatabaseAuthentication.dll /app/Authentication/CDP4WspDatabase/CDP4WspDatabaseAuthentication.dll
 COPY --from=build-env /app/CDP4WspDatabaseAuthentication/bin/Release/config.json /app/Authentication/CDP4WspDatabase/config.json
+
+COPY --from=build-env /app/VersionFileCreator/bin/Release /app/VersionFileCreator
+RUN dotnet /app/VersionFileCreator/VersionFileCreator.dll path:/app
+RUN rm -r /app/VersionFileCreator
 
 # set to use the non-root USER here
 RUN chown -R $APP_UID /app

--- a/VersionFileCreator/VersionFileCreator.csproj
+++ b/VersionFileCreator/VersionFileCreator.csproj
@@ -14,6 +14,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[FIX] Version file update on runtime server instead of build server