### PR TITLE
Fix bug on DLL resolve for plugins

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -79,7 +79,7 @@ jobs:
         run: dotnet-coverage collect --output CoverageResults/integration.test.report.coverage.xml --output-format cobertura --session-id integrationtestsession "dotnet run --project CometServer/CometServer.csproj -c Debug" &
 
       - name: Wait for API to start
-        run: sleep 45  # Adjust as necessary to ensure the API is up
+        run: sleep 60  # Adjust as necessary to ensure the API is up
 
       - name: Checkout Integration Test Suite
         uses: actions/checkout@v4


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/COMET-WebServices-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-SDK [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/COMET-WebServices-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
If a loaded plugin requires DLL that is not part of the referenced CDP4 COMET Server, those DLL are not loaded and the system is unable to resolve them, which leads to runtime exception and additional Authentication plugin may not work.

This code resolve this issue, tracks all DLL that has been discovered and loaded during the LoadPlugins process and help resolving missing DLL
<!-- Thanks for contributing to COMET Web Services! -->