### PR TITLE
Add unit tests for CDP4Authentication classes

### DIFF
--- a/CDP4Authentication.Tests/AuthenticatorPropertiesTestFixture.cs
+++ b/CDP4Authentication.Tests/AuthenticatorPropertiesTestFixture.cs
@@ -1,0 +1,128 @@
+namespace CDP4Authentication.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AuthenticatorPropertiesTestFixture
+    {
+        [Test]
+        public void AuthenticatorProperties_ShouldStoreAssignedValues()
+        {
+            var properties = new AuthenticatorProperties
+            {
+                Rank = 1,
+                IsEnabled = true,
+                Name = "TestAuthenticator",
+                Description = "Authenticator used for unit testing"
+            };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(properties.Rank, Is.EqualTo(1));
+                Assert.That(properties.IsEnabled, Is.True);
+                Assert.That(properties.Name, Is.EqualTo("TestAuthenticator"));
+                Assert.That(properties.Description, Is.EqualTo("Authenticator used for unit testing"));
+            });
+        }
+
+        [Test]
+        public void AuthenticationPerson_ShouldInitializeRequiredProperties()
+        {
+            var iid = Guid.NewGuid();
+            const int revision = 5;
+
+            var person = new AuthenticationPerson(iid, revision);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(person.Iid, Is.EqualTo(iid));
+                Assert.That(person.RevisionNumber, Is.EqualTo(revision));
+                Assert.That(person.IsActive, Is.False);
+                Assert.That(person.IsDeprecated, Is.False);
+                Assert.That(person.Password, Is.Null);
+                Assert.That(person.UserName, Is.Null);
+                Assert.That(person.Salt, Is.Null);
+                Assert.That(person.Role, Is.Null);
+                Assert.That(person.DefaultDomain, Is.Null);
+                Assert.That(person.Organization, Is.Null);
+            });
+        }
+
+        [Test]
+        public void AuthenticationPerson_ShouldAllowUpdatingOptionalProperties()
+        {
+            var iid = Guid.NewGuid();
+            const int revision = 10;
+            var person = new AuthenticationPerson(iid, revision)
+            {
+                Password = "password",
+                UserName = "user",
+                IsActive = true,
+                IsDeprecated = true,
+                Salt = "salt",
+                Role = Guid.NewGuid(),
+                DefaultDomain = Guid.NewGuid(),
+                Organization = Guid.NewGuid()
+            };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(person.Password, Is.EqualTo("password"));
+                Assert.That(person.UserName, Is.EqualTo("user"));
+                Assert.That(person.IsActive, Is.True);
+                Assert.That(person.IsDeprecated, Is.True);
+                Assert.That(person.Salt, Is.EqualTo("salt"));
+                Assert.That(person.Role, Is.Not.Null);
+                Assert.That(person.DefaultDomain, Is.Not.Null);
+                Assert.That(person.Organization, Is.Not.Null);
+            });
+        }
+
+        [Test]
+        public void AuthenticatorConfig_ShouldMaintainConnectorProperties()
+        {
+            var connectorProperties = new AuthenticatorProperties
+            {
+                Rank = 2,
+                IsEnabled = true,
+                Name = "Connector",
+                Description = "Connector description"
+            };
+
+            var config = new AuthenticatorConfig<AuthenticatorProperties>
+            {
+                AuthenticatorConnectorProperties = new List<AuthenticatorProperties> { connectorProperties }
+            };
+
+            Assert.That(config.AuthenticatorConnectorProperties, Is.Not.Null);
+            Assert.That(config.AuthenticatorConnectorProperties, Has.Count.EqualTo(1));
+            Assert.That(config.AuthenticatorConnectorProperties[0], Is.SameAs(connectorProperties));
+        }
+
+        [Test]
+        public void AuthenticatorWspProperties_ShouldStoreServerSalts()
+        {
+            var serverSalts = new[] { "salt1", "salt2" };
+
+            var wspProperties = new AuthenticatorWspProperties
+            {
+                Rank = 3,
+                IsEnabled = false,
+                Name = "Wsp",
+                Description = "WSP description",
+                ServerSalts = serverSalts
+            };
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(wspProperties.Rank, Is.EqualTo(3));
+                Assert.That(wspProperties.IsEnabled, Is.False);
+                Assert.That(wspProperties.Name, Is.EqualTo("Wsp"));
+                Assert.That(wspProperties.Description, Is.EqualTo("WSP description"));
+                Assert.That(wspProperties.ServerSalts, Is.SameAs(serverSalts));
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add NUnit tests for the AuthenticatorProperties and AuthenticatorWspProperties models
- cover AuthenticationPerson constructor and property setters
- exercise AuthenticatorConfig connector storage behaviour

## Testing
- dotnet test CDP4Authentication.Tests/CDP4Authentication.Tests.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d908ed626c83268311d0f61c6a42ec